### PR TITLE
Poseidon sponge construction

### DIFF
--- a/poseidon-permutation.md
+++ b/poseidon-permutation.md
@@ -1,0 +1,30 @@
+# Poseidon permutation
+
+- Version: 0.0.0
+- Maintainer: Jack Grigg
+
+## Introduction
+
+This document specifies the Poseidon permutation.
+
+> TODO: Explain why Poseidon is useful:
+> - Binary hash functions are inefficient in algebraic circuits.
+
+For the Poseidon hash functions, see [this document](./poseidon-sponge.md).
+
+## Notation and conventions
+
+- `[a, b)` means the sequence of integers from `a` inclusive to `b` exclusive.
+
+## Constants
+
+> TODO
+
+## Round function components
+
+> TODO
+
+## Permutation
+
+> TODO: Specify to match v1.1 of the Poseidon permutation reference implementation
+> (https://extgit.iaik.tugraz.at/krypto/hadeshash/-/commit/659de89cd207e19b92852458dce92adf83ad7cf7).

--- a/poseidon-sponge.md
+++ b/poseidon-sponge.md
@@ -1,0 +1,145 @@
+# Poseidon sponge construction
+
+- Version: 0.0.0
+- Maintainer: Jack Grigg
+
+## Introduction
+
+This document specifies the Poseidon sponge construction, a duplex sponge [[BDPV2011]]
+instantiated with the [Poseidon permutation]. It also specifies several instantiations of
+the sponge for use in various hashing domains.
+
+[BDPV2011]: https://keccak.team/files/SpongeDuplex.pdf
+[Poseidon permutation]: ./poseidon-permutation.md
+
+## Notation and conventions
+
+- `[a, b)` means the sequence of integers from `a` inclusive to `b` exclusive.
+- `[x; N]` means an array of length `N` where every entry is filled with `x`.
+- `y[i]` means the element of the array `y` at index `i`.
+- `len(y)` means the length of the array `y`. For example, `len([x; N]) == N`.
+
+## Duplex sponge
+
+The duplex sponge `PoseidonSponge` is built around `PoseidonPermutation`, a permutation of
+width `T`, which encapsulates the specific Poseidon parameters for the sponge. It has a
+parameter `RATE`, the number of input field elements processed by each invocation of the
+permutation, which is at most `T - 1`. The value `C = T - RATE` is called the capacity.
+
+> TODO: Describe how the permutation instance and the rate relate to each other and to the
+> desired security parameter `M`.
+
+`PoseidonSponge` has several internal properties:
+- An internal state of `T` field elements.
+- A mode variable that is either `absorbing` or `squeezing`.
+- A cache of field elements corresponding to the current mode.
+- A padding operation to be applied to input elements prior to incorporating them into the
+  sponge state.
+  > TODO: See TODO below about how to define this operation.
+
+The only operations exposed by the sponge are:
+- `PoseidonSponge.Initialize`, which prepares a new sponge.
+- `PoseidonSponge.Absorb`, which takes a single field element into the sponge.
+- `PoseidonSponge.Squeeze`, which produces a single field element derived from all prior
+  `Absorb` and `Squeeze` operations on the sponge, as well as the initialization values.
+
+`PoseidonSponge.Initialize` must only be called once per sponge, and must be called first.
+After that, `PoseidonSponge.Absorb` and `PoseidonSponge.Squeeze` may be called repeatedly
+and in any order.
+
+The sponge has an internal state of width `T`, divided into two sections:
+- Field elements at indices `[0, RATE)` form the "rate" portion of the sponge.
+- Field elements at indices `[RATE, T)` (the last `C` field elements of the state) form
+  the capacity portion of the sponge. These elements are never directly affected by the
+  input field elements, and are never output during the squeezing phase.
+
+> Note: Both the duplex sponge construction from [[BDPV2011]], and the plain sponge
+> construction it is derived from [[BDPV2007]], use an internal state with the form
+> `rate || capacity`. Section 2.1 of the Poseidon paper matched this internal state form
+> when specifying the Poseidon sponge. However, Appendix I of the Poseidon paper (which
+> describes a particular use of the Poseidon sponge within Merkle tree hashing) used
+> `capacity || rate` instead, and at least one instance of Poseidon Merkle tree hashing
+> matching Appendix I was deployed into production before this inconsistency was noticed.
+>
+> TODO: Examine all open-source production instances of Poseidon to figure out how far
+> this inconsistency propagated, and what other variants might currently exist.
+
+[BDPV2007]: https://keccak.team/files/SpongeFunctions.pdf
+
+### Domain separation and padding
+
+> TODO
+
+### Initialization
+
+`PoseidonSponge.Initialize` takes as input a `PoseidonPermutation`, and a domain in which
+the sponge will be used, and proceeds as follows:
+
+1. Obtain `initial_capacity_value` and `padding_operation` from the domain.
+   > TODO: Define this.
+2. `state = [0; T]`.
+3. `state[RATE] = initial_capacity_value`.
+   > TODO: Will `initial_capacity_value` ever require more than one field element? We can
+   > have a minimum field element size requirement that ensures one field element is large
+   > enough.
+4. Return `PoseidonSponge(state, mode = absorbing, cache = [], padding_operation)`.
+
+### Internal helper functions
+
+`PoseidonSponge.PerformDuplex` takes an input of between zero and `RATE` field elements.
+It proceeds as follows:
+
+1. Apply the domain's padding function to the input, resulting in a padded input of `RATE`
+   field elements.
+   > TODO: What about the variable-length case: is padding logically applied here to the
+   > input chunk, or to the entire input? The latter seems more sensible as otherwise if
+   > the variable length is a multiple of `RATE` then we can't detect here that padding is
+   > necessary. But we _do_ need a padding function inside the duplex sponge or else we
+   > can't run the permutation correctly.
+
+2. Add the padded input element-wise to the rate portion of `state`:
+   ```
+   for i in [0, RATE):
+       state[i] += padded_input[i]
+   ```
+
+3. Call `PoseidonPermutation(state)`.
+
+4. Return the first `RATE` field elements of `state` as output.
+
+### Absorb
+
+`PoseidonSponge.Absorb` takes a single field element `input`, and proceeds as follows:
+
+- If `mode == absorbing`:
+  - If `len(cache) == RATE`:
+    1. Call `PoseidonSponge.PerformDuplex(cache)`, and drop the result.
+    2. Set `cache` to `[input; 1]`.
+
+  - Else (there is room in `cache`):
+    1. Append `input` to the end of `cache`.
+
+- Else (`mode == squeezing`):
+  1. Drop any remaining cached output elements (by setting `cache` to `[]`).
+  2. Set `mode` to `absorbing`.
+  3. Set `cache` to `[input; 1]`.
+
+### Squeeze
+
+`PoseidonSponge.Squeeze` proceeds as follows:
+
+1. If `mode == squeezing` and `len(cache) == 0`:
+   1. Set `mode` to `absorbing`.
+   2. Set `cache` to `[]` (this is already the case, but for clarity this means there are
+      no elements to be absorbed).
+
+2. If `mode == absorbing`:
+   1. `new_output_elements = PoseidonSponge.PerformDuplex(cache)`.
+   2. Set `mode` to `squeezing`.
+   3. Set `cache` to `new_output_elements`.
+
+3. Remove the first element from `cache` and return it.
+
+## High-level constructions
+
+> TODO

--- a/poseidon-sponge.md
+++ b/poseidon-sponge.md
@@ -149,6 +149,40 @@ It proceeds as follows:
 
 ## Hash functions
 
+### Merkle tree digest
+
+Merkle trees are built around `arity`-to-1 compression functions, that combine a set of
+nodes from one tree layer into a single node in the next layer.
+
+> TODO: Explain more clearly why the Merkle tree digest outputs `C` elements (as it's
+> confusing on its face that it becomes an `arity`-to-`C` compression function).
+
+`PoseidonHash.MerkleTree` takes as input:
+
+- The `arity` of the Merkle tree, of maximum value 32.
+  - The `RATE` of the sponge is set to `arity`.
+- A `PoseidonPermutation` with the desired properties; in particular, its width `T` must
+  equal `arity + C`, where `C` depends on the desired security level `M`.
+- `nodes`, an array of `arity` field elements.
+
+The digest proceeds as follows:
+
+```
+sponge = PoseidonSponge.Initialize(
+    PoseidonPermutation,
+    (1 << arity) - 1,
+    ZeroExtend,
+)
+
+for i in [0, arity):
+    sponge.Absorb(nodes[i])
+
+output = [0; C]
+for i in [0, C):
+    output[i] = sponge.Squeeze()
+return output
+```
+
 ### Hash function with fixed-length input
 
 `PoseidonHash.ConstantLength` takes as input:


### PR DESCRIPTION
Draft 0.1.0 specifies what I implemented for [Zcash's `orchard` crate](https://github.com/zcash/orchard/blob/main/src/primitives/poseidon.rs), which was a direct reading of the Poseidon paper as applied to a "generalised duplex sponge" (https://eprint.iacr.org/2011/499 generalised to allow calling `Absorb` and `Squeeze` in any sequence or order).

The goal here is to figure out a specification that multiple projects planning to use Poseidon can agree upon. Compatibility with all existing production implementations of Poseidon is not possible (because they are incompatible with each other), so priority is given to making this a sensible specification (within the time constraints of Zcash needing to commit to a construction, within the next few weeks), and (some level of) compatibility with (some subset of) existing implementations is a secondary nice-to-have.

TODOs I want to address before merging this as 0.1.0:
- [ ] Specify Poseidon permutation.
- [x] Figure out how to specify domain separation / padding.
- [x] Decide how to specify the initial capacity value(s).
- [x] Specify hash functions instantiated on the Poseidon sponge.

Other TODOs will be left in the specification documents; we can resolve them in subsequent PRs.