### PR TITLE
age: Fix byte value typo.

### DIFF
--- a/age.md
+++ b/age.md
@@ -67,7 +67,7 @@ or at the first line shorter than 64 columns (for stanzas).
 #### Version line
 
 The version line always starts with "age-encryption.org/", is followed by an
-arbitrary version string, and ends with a line feed (`0x0a`).
+arbitrary version string, and ends with a line feed (`0x0A`).
 
     version-line = %s"age-encryption.org/" version LF
 

--- a/age.md
+++ b/age.md
@@ -67,7 +67,7 @@ or at the first line shorter than 64 columns (for stanzas).
 #### Version line
 
 The version line always starts with "age-encryption.org/", is followed by an
-arbitrary version string, and ends with a line feed (`0x20`).
+arbitrary version string, and ends with a line feed (`0x0a`).
 
     version-line = %s"age-encryption.org/" version LF
 


### PR DESCRIPTION
Noticed this while reading through the age specification and the draft plugin spec. I didn't see any precedent in this doc for uppercase vs. lowercase hex; went with lowercase, but happy to change if you prefer.

In any case, thank you for all your work on age and open source!