### PR TITLE
WIP: Batched Merkle Audit Paths

### DIFF
--- a/bpath.md
+++ b/bpath.md
@@ -1,0 +1,79 @@
+# Batched Merkle Inclusion Proofs
+
+This document defines the `BPATH` algorithm for proving inclusion of multiple leaves in a Merkle tree. This standard extends the `PATH` function defined in the Certificate Transparency standard, [RFC 6962][]. `BPATH` is equivalent to `PATH` whenever just one leaf's membership is being proved.
+
+## Conventions used in this document
+
+We use the same notation as in [RFC 6962][]. `D[n]` denotes a list of `n` elements: `{d(0), d(1), ..., d(n-1)}`. `D[k1:k2]` denotes the length `(k2 - k1)` list `{d(k1), d(k1+1), ..., d(k2-1)}`. `D : E` denotes the concatenation of lists `D` and `E`. When `c` is an integer and `M[r]` is a list of integers, `M[k1:k2] - c` denotes the list `{m(k1) - c, m(k1+1) - c, ..., d(k2-1) - c}`. `MTH(D[n])` denotes the Merkle Tree Hash of `D[n]`, i.e., the root of the complete Merkle Tree whose leaves are the elements of `D[n]`. Finally, `I2OSP(n, w)` denotes the function that returns the width-`w` big-endian encoding of the non-negative integer `n`, as described in [RFC 8017][].
+
+As in [RFC 6962][], the algorithm defined in this document is generic over the choice of hash function, and we do not fix a canonical hash function. We provide test vectors over the `SHA-256` [FIPS 180-4][], `BLAKE2s` [RFC 7693][], and `SHAKE256` [FIPS 202][] hash functions. Python 3 code is provided for end users who wish to generate test vectors using other hash functions.
+
+## Batch Merkle Audit Paths
+
+We extend the `PATH` function defined in [RFC 6962, section 2.1.1][PATH def]. Given a list of leaves `D[n]` and an index `m` with `0 <= m < n`, `PATH` produces a proof that `d(m)` appears in `D[n]`. A verifier of a `PATH` proof need only know `d(m)` and `MTH(D[n])` in order to verify the proof. `BPATH` is the batched version of `PATH`: it constructs a proof that multiple leaves, whose indices are given by a (sorted) list `M[r]`, appear in `D[n]`. A verifier of `BPATH` proof need only know `{d(m(0)), ..., d(m(r-1))}` and `MTH(D[n])` in order to verify the proof.
+
+The purpose of `BPATH` is to produce much smaller proofs of multiple inclusion. Semantically, a `BPATH` proof over `M[r]` is equivalent to `r` `PATH` proofs, one for each individual index. However, the `r` `PATH` proofs may contain large amounts of redundant information. For example, using a hash function with 256-bit digests, the full set of `PATH` proofs for the first 100 leaves in a 1000-leaf tree is 32KB, whereas the `BPATH` proof for the same set is 192B (0.6%). A `BPATH` proof is smaller than the corresponding set of `PATH` proofs whenever `r > 1`.
+
+Finally, as stated above, `BPATH` is backwards compatible with `PATH`. Concretely, `BPATH({m}, D[n]) == PATH(m, D[n])` for all lists `D[n]` and integers `m` where `0 < m <= n`.
+
+### Definition
+ 
+Given a list of `n` leaves, `D[n] = {d(0), ..., d(n-1)}`, and a list of `r` indices `M[r] = {m(0), ..., m(r-1)}` with `0 <= m(0) < ... m(r-1) < n`, the batched Merkle audit path `BPATH(M[r], D[n])` is defined as follows.
+
+The batched proof for the single leaf in a tree with a one-element input list `D[1] = {d(0)}` is empty:
+
+```
+BPATH({0}, {d(0)}) = {}
+```
+
+For `n > 1`, let `k` be the largest power of two smaller than `n`. Let `l` be the largest integer such that `m(i) < k` for all `i < l`, i.e., all of `M[0:l]` is in the left subtree of `D[n]`, and all of `M[l:r]` is in the right subtree of `D[n]`.
+
+In the case `l == r`, no index `m(i)` is in the right subtree, so the batch proof must provide the right subtree hash. Similarly, in the case `l == 0`, no `m(i)` is in the left subtree, so the batch proof must provide the left subtree hash. In all other cases, both subtrees must be recursed upon. Concretely, the batched path is defined in the recursive as:
+
+```
+if l == r:
+    BPATH(M[r], D[n]) = BPATH(M[r], D[0:k]) : MTH(D[k:n])
+else if l == 0:
+    BPATH(M[r], D[n]) = BPATH(M[r] - k, D[k:n]) : MTH(D[0:k])
+else:
+    BPATH(M[r], D[n]) =
+        BPATH(M[0:l], D[0:k]) : BPATH(M[l:r] - k, D[k:n])
+```
+
+## Test Vectors
+
+We provide test vectors in **[TODO: pick a place to put these]**, not just for `BPATH`, but also for the Merkle tree functions defined in [RFC 6962][]. Python 3 test vector generation code can be found at **[TODO: pick a place for this too]**.
+
+In each test vector, the `num_leaves` key indicates the number of leaves in the tree `D[num_leaves]`. Each leaf `d(i)` is defined to be `I2OSP(i, 2)`, i.e., the 2 byte big-endian representation of the integer `i`. The structure of the test vectors is as follows:
+
+**TODO: Update structures once KATs for other hash functions are written**
+
+### Merkle Tree Hash (`mth.json`)
+
+* `num_leaves` - The number of leaves in the tree
+* `tree_hash` - The value of `MTH(D[num_leaves])`, encoded in hex
+
+### Merkle Audit Path (`path.json`)
+
+* `num_leaves` - The number of leaves in the tree
+* `idx` - The index of the leaf whose membership is being proved
+* `inclusion_proof` - The value of `PATH(idx, D[num_leaves])`, encoded in hex
+
+### Batch Merkle Audit Path (`bpath.json`)
+
+* `num_leaves` - The number of leaves in the tree
+* `idxs` - The indices of the leaves whose memberships are being batch-proved
+* `batch_inclusion_proof` - The value of `BPATH(idxs, D[num_leaves])`, encoded in hex
+
+### Consistency Proof (`consistency.json`)
+
+* `num_leaves` - The number of leaves in the tree
+* `subtree_size` - The size of the left subtree which we want to show is consistent with `D[num_leaves]`
+* `consistency_proof` - The value of `PROOF(subtree_size, D[num_leaves])`, encoded in hex
+
+[RFC 6962]: https://www.rfc-editor.org/info/rfc6962
+[RFC 7693]: https://www.rfc-editor.org/info/rfc7693
+[RFC 8017]: https://www.rfc-editor.org/info/rfc8017
+[PATH def]: https://datatracker.ietf.org/doc/html/rfc6962#section-2.1.1
+[FIPS 180-4]: http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf
+[FIPS 202]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf

--- a/bpath_ref.py
+++ b/bpath_ref.py
@@ -1,0 +1,246 @@
+from hashlib import sha256
+from math import log2, floor
+
+# Returns the largest power of 2 smaller than n
+def prev_power_of_two(n):
+    # This is the largest power of 2 no greater than n-1, i.e., k <= n-1, i.e., largest power of 2
+    # smaller than n.
+    return 2 ** floor(log2(n-1))
+
+# RFC 6962 §2.1 - Merkle Hash Trees
+# Base def:
+#     MTH({d(0)}) = SHA-256(0x00 || d(0))
+# Recursive defs: For m < n, let k be the largest power of two smaller than n.
+#     MTH(D[n]) = SHA-256(0x01 || MTH(D[0:k]) || MTH(D[k:n]))
+def mth(d):
+    n = len(d)
+    if n == 1:
+        return sha256(b"\x00" + d[0]).digest()
+    else:
+        k = prev_power_of_two(n)
+        return sha256(b"\x01" + mth(d[0:k]) + mth(d[k:n])).digest()
+
+# RFC 6962 §2.1.1 - Merkle Audit Paths
+# Base def:
+#     PATH(0, {d(0)}) = {}
+# Recursive defs: For m < n, let k be the largest power of two smaller than n.
+#     PATH(m, D[n]) = PATH(m, D[0:k]) : MTH(D[k:n])      if m < k
+#     PATH(m, D[n]) = PATH(m - k, D[k:n]) : MTH(D[0:k])  if m >= k
+def path(m, d):
+    n = len(d)
+    if n == 1:
+        return b""
+    else:
+        k = prev_power_of_two(n)
+        if m < k:
+            return path(m, d[0:k]) + mth(d[k:n])
+        else:
+            return path(m - k, d[k:n]) + mth(d[0:k])
+
+# RFC 6962 §2.1.2 - Merkle Consistency Proofs
+# Base defs: For 0 < m < n,
+#     PROOF(m, D[n]) = SUBPROOF(m, D[n], true)
+#     SUBPROOF(m, D[m], true) = {}
+#     SUBPROOF(m, D[m], false) = {MTH(D[m])}
+# Recursive defs: For m < n, let k be the largest power of two smaller than n.
+#     SUBPROOF(m, D[n], b) = SUBPROOF(m, D[0:k], b) : MTH(D[k:n])          if m <= k
+#     SUBPROOF(m, D[n], b) = SUBPROOF(m - k, D[k:n], false) : MTH(D[0:k])  if m > k
+def proof(m, d):
+    def subproof(m, d, b):
+        n = len(d)
+        if m == n:
+            if b:
+                return b""
+            else:
+                return mth(d)
+        else:
+            k = prev_power_of_two(n)
+            if m <= k:
+                return subproof(m, d[0:k], b) + mth(d[k:n])
+            else:
+                return subproof(m - k, d[k:n], False) + mth(d[0:k])
+
+    return subproof(m, d, True)
+
+# This spec
+# Base def:
+#     BPATH({0}, {d(0)}) = {}
+# Recursive defs: For n > 1, let k be the largest power of two smaller than n. Let l be the largest
+# integer such that m(i) < k for all i < l.
+#     BPATH(M[r], D[n]) = BPATH(M[r], D[0:k]) : MTH(D[k:n])                  if l == r
+#     BPATH(M[r], D[n]) = BPATH(M[r] - k, D[k:n]) : MTH(D[0:k])              if l == 0:
+#     BPATH(M[r], D[n]) = BPATH(M[0:l], D[0:k]) : BPATH(M[l:r] - k, D[k:n])  else
+def bpath(m, d):
+    n = len(d)
+    r = len(m)
+
+    if n == 1:
+        return b""
+    else:
+        k = prev_power_of_two(n)
+        l = 0
+        while l < r and m[l] < k:
+            l += 1
+
+        if l == r:
+            return bpath(m, d[0:k]) + mth(d[k:n])
+        elif l == 0:
+            return bpath([mi - k for mi in m], d[k:n]) + mth(d[0:k])
+        else:
+            return bpath(m[0:l], d[0:k]) + bpath([mi - k for mi in m[l:r]], d[k:n])
+
+
+#
+# Generate test vectors
+#
+if __name__ == "__main__":
+    from random import randbytes, randrange, sample, seed as randseed
+    import json
+
+    # Make the RNG deterministic
+    randseed(b"C2SP Batch Merkle Audit Path")
+
+    max_num_leaves = 64
+
+    # Make a tree `D[n]` where `d(i)` is the two-byte big-endian representation of the integer `i`.
+    def gen_leaves(n):
+        return [i.to_bytes(2, byteorder="big") for i in range(n)]
+
+    # Make 10 test vectors for MTH
+    mth_test_vecs = []
+    for _ in range(10):
+        num_leaves = randrange(1, max_num_leaves)
+        leaves = gen_leaves(num_leaves)
+        h = mth(leaves)
+
+        mth_test_vecs.append({
+            "num_leaves": num_leaves,
+            "tree_hash": h.hex(),
+        })
+
+    # Make 100 test vectors for PATH
+    inclusion_test_vecs = []
+    for _ in range(100):
+        num_leaves = randrange(1, max_num_leaves+1)
+        leaves = gen_leaves(num_leaves)
+        idx = randrange(num_leaves)
+
+        inclusion_proof = path(idx, leaves)
+        inclusion_test_vecs.append({
+            "num_leaves": num_leaves,
+            "idx": idx,
+            "inclusion_proof": inclusion_proof.hex(),
+        })
+
+        # Check that PATH == BPATH for single-idx proofs
+        assert(inclusion_proof == bpath([idx], leaves))
+
+    # Make 100 test vectors for BPATH using random subsets
+    batch_inclusion_test_vecs = []
+    for _ in range(100):
+        num_leaves = randrange(1, max_num_leaves+1)
+        leaves = gen_leaves(num_leaves)
+
+        batch_size = randrange(1, num_leaves+1)
+
+        idxs = sample(range(num_leaves), batch_size)
+        idxs.sort()
+
+        batch_inclusion_proof = bpath(idxs, leaves)
+        batch_inclusion_test_vecs.append({
+            "num_leaves": num_leaves,
+            "idxs": idxs,
+            "batch_inclusion_proof": batch_inclusion_proof.hex(),
+        })
+
+    # Make 100 test vectors for BPATH using random continguous slices
+    for _ in range(100):
+        num_leaves = randrange(1, max_num_leaves+1)
+        leaves = gen_leaves(num_leaves)
+        batch_size = randrange(1, num_leaves+1)
+
+        start_idx = randrange(num_leaves)
+        max_end_idx = min(start_idx + batch_size, num_leaves) + 1;
+        end_idx = randrange(start_idx + 1, max_end_idx);
+
+        idxs = list(range(start_idx, end_idx))
+        idxs.sort()
+
+        batch_inclusion_proof = bpath(idxs, leaves)
+        batch_inclusion_test_vecs.append({
+            "num_leaves": num_leaves,
+            "idxs": idxs,
+            "batch_inclusion_proof": batch_inclusion_proof.hex(),
+        })
+
+    # Make 100 test vectors for PROOF
+    consistency_test_vecs = []
+    for _ in range(100):
+        num_leaves = randrange(2, max_num_leaves+1)
+        leaves = gen_leaves(num_leaves)
+        subtree_size = randrange(1, num_leaves)
+
+        consistency_proof = proof(subtree_size, leaves)
+        consistency_test_vecs.append({
+            "num_leaves": num_leaves,
+            "subtree_size": subtree_size,
+            "consistency_proof": consistency_proof.hex(),
+        })
+
+    with open("mth.json", "w+") as f:
+        json.dump(mth_test_vecs, f, indent=2)
+    with open("path.json", "w+") as f:
+        json.dump(inclusion_test_vecs, f, indent=2)
+    with open("bpath.json", "w+") as f:
+        json.dump(batch_inclusion_test_vecs, f, indent=2)
+    with open("consistency.json", "w+") as f:
+        json.dump(consistency_test_vecs, f, indent=2)
+
+    # TODO: Make test vectors that should not verify
+    # TODO: Make test vectors for other hash functions
+    # TODO: Decide whether to make normative verification section. If so, make should_panic test
+    # vectors as well
+
+    '''
+    #
+    # Make test vectors that should cause a panic
+    #
+
+    # idx < num_leaves for PATH. We violate this here:
+    num_leaves = randrange(1, max_num_leaves+1)
+    idx = num_leaves
+    inclusion_panic_test_vec = {
+        "num_leaves": num_leaves,
+        "idx": idx,
+    }
+    print(f"{inclusion_panic_test_vec=}")
+
+    # idx[i] < num_leaves for all i in BPATH. We violate this by setting 1 idx out of range
+    num_leaves = randrange(1, max_num_leaves+1)
+    idxs = sample(range(num_leaves), batch_size)
+    idxs[randrange(batch_size)] = num_leaves
+    idxs.sort()
+    batch_inclusion_panic_test_vec = {
+        "num_leaves": num_leaves,
+        "idxs": idxs,
+    }
+    print(f"{batch_inclusion_panic_test_vec=}")
+
+    # subtree_size < num_leaves for PROOF. We violate this here:
+    num_leaves = randrange(1, max_num_leaves+1)
+    subtree_size = num_leaves
+    proof_panic_test_vec_1 = {
+        "num_leaves": num_leaves,
+        "subtree_size": subtree_size,
+    }
+    print(f"{proof_panic_test_vec_1=}")
+
+    # subtree_size > 0 for PROOF. We violate this here:
+    num_leaves = randrange(1, max_num_leaves+1)
+    subtree_size = 0
+    proof_panic_test_vec_2 = {
+        "num_leaves": num_leaves,
+        "subtree_size": subtree_size,
+    }
+    print(f"{proof_panic_test_vec_2=}")
+    '''


### PR DESCRIPTION
[Rendered](https://github.com/rozbb/C2SP/blob/bpath/bpath.md)

This small standard (and Python 3 ref impl and test vectors) defines a batched version of [Certificate Transparency-compatible Merkle membership proofs](https://datatracker.ietf.org/doc/html/rfc6962#section-2.1.1). The TL;DR is that it's a more space-efficient way of proving membership of multiple elements in a Merkle tree. As an example: the size of a membership proof of the first 100 elements in a 1000-element tree is reduced by over 99% by using a batched proof, rather than using 100 individual membership proofs.

This is compatible with the original CT proofs in that it produces identical proofs whenever `n = 1`.

I've also got a Rust impl that's passing known-answer tests [here](https://github.com/rozbb/ct-merkle/blob/batch-inclusion/src/batch_inclusion.rs).

Unresolved items:

* Should figure out whether I want to define a verification algorithm. The original spec doesn't define one, probably because you'd have to introduce a lot more math to describe it in sufficient details
* **PLEASE GIVE INPUT:** Should decide whether or not to make a normative statement on valid vs invalid proofs. It is very likely that there are CT verification algorithms out there that will verify on proofs that are too long (i.e., the verifier will have computed the root, and not even looked at the remaining bytes in the proof). Is an overly long proof still a valid proof? It breaks canonicity, and we know that bad things happen when you break canonicity.
    * Another example of ambiguity is whether or not empty proofs are allowed in the `PROOF` function (proving Merkle tree consistency). Technically, the CT spec doesn't define `PROOF` for trivial inputs (subtree == main tree), but [some implementations](https://github.com/transparency-dev/merkle/blob/e739733c8ca2b89cfc49f35b161e81e16b5957d7/testonly/reference_test.go#L129) will happily produce and verify these kinds of proofs. I think it's wrong, but I have to decide how much I should care.
* Need to figure out the correct place to put the multiple JSON test vectors and Python 3 reference impl. @FiloSottile do you have opinions here?

Open to any and all comments!