### PR TITLE
vrf-r255: Update references to point to draft-irtf-cfrg-vrf-15

### DIFF
--- a/vrf-r255.md
+++ b/vrf-r255.md
@@ -3,9 +3,9 @@
 [c2sp.org/vrf-r255](https://c2sp.org/vrf-r255)
 
 This document defines the ECVRF-RISTRETTO255-SHA512 ciphersuite of the ECVRF
-construction specified in [draft-irtf-cfrg-vrf-11][], similarly to
-[draft-irtf-cfrg-vrf-11, Section 5.5][] and according to
-[draft-irtf-cfrg-vrf-11, Section 7.10][].
+construction specified in [draft-irtf-cfrg-vrf-15][], similarly to
+[draft-irtf-cfrg-vrf-15, Section 5.5][] and according to
+[draft-irtf-cfrg-vrf-15, Section 7.10][].
 
 ## Conventions used in this document
 
@@ -49,7 +49,7 @@ document are to be interpreted as described in [BCP 14][] [RFC 2119][]
 
     * In practice, most implementations neither will nor should deal with
       arbitrary integer types. Instead, every time this document or
-      draft-irtf-cfrg-vrf-11 use `int_to_string` and `string_to_int` or perform
+      draft-irtf-cfrg-vrf-15 use `int_to_string` and `string_to_int` or perform
       arithmetic on integers, they're operating on elements of the scalar field
       (integers modulo `q`).
 
@@ -112,14 +112,14 @@ Steps:
 ### Encode to curve
 
 The [PWHVNRG17] proof models `ECVRF_encode_to_curve` as a random oracle separate
-from any other `Hash` instantiation. [draft-irtf-cfrg-vrf-11, Section 7.8][]
+from any other `Hash` instantiation. [draft-irtf-cfrg-vrf-15, Section 7.8][]
 argues that it's ok to use [irtf-cfrg-hash-to-curve][] for `ECVRF_encode_to_curve`
 because it will always invoke `Hash` with a non-zero final input byte, while most
 other uses of `Hash` in the document append a zero byte to the input. Since
 ristretto255 provides a one-way map and `hLen` is conveniently the same size as
 its input, in this document we get to skip all that complexity and use an
 instantiation of `Hash` that's domain-separated like every other hash use in
-draft-irtf-cfrg-vrf-11.
+draft-irtf-cfrg-vrf-15.
 
 `ECVRF_encode_to_curve(encode_to_curve_salt, alpha_string)`
 
@@ -187,10 +187,10 @@ beta = dd653f0879b48c3ef69e13551239bec4cbcc1c18fe8894de2e9e1c790e182736
     03bf1c6c25d7a797aeff3c43fd32b974d3fcbd4bcce916007097922a3ea3a794
 ```
 
-[draft-irtf-cfrg-vrf-11]: https://www.ietf.org/archive/id/draft-irtf-cfrg-vrf-11.html
-[draft-irtf-cfrg-vrf-11, Section 5.5]: https://www.ietf.org/archive/id/draft-irtf-cfrg-vrf-11.html#name-ecvrf-ciphersuites
-[draft-irtf-cfrg-vrf-11, Section 7.10]: https://www.ietf.org/archive/id/draft-irtf-cfrg-vrf-11.html#name-futureproofing
-[draft-irtf-cfrg-vrf-11, Section 7.8]: https://www.ietf.org/archive/id/draft-irtf-cfrg-vrf-11.html#name-hash-function-domain-separa
+[draft-irtf-cfrg-vrf-15]: https://www.ietf.org/archive/id/draft-irtf-cfrg-vrf-15.html
+[draft-irtf-cfrg-vrf-15, Section 5.5]: https://www.ietf.org/archive/id/draft-irtf-cfrg-vrf-15.html#name-ecvrf-ciphersuites
+[draft-irtf-cfrg-vrf-15, Section 7.10]: https://www.ietf.org/archive/id/draft-irtf-cfrg-vrf-15.html#name-futureproofing
+[draft-irtf-cfrg-vrf-15, Section 7.8]: https://www.ietf.org/archive/id/draft-irtf-cfrg-vrf-15.html#name-hash-function-domain-separa
 [BCP 14]: https://www.rfc-editor.org/info/bcp14
 [RFC 2119]: https://www.rfc-editor.org/info/rfc2119
 [RFC 8174]: https://www.rfc-editor.org/info/rfc8174
@@ -203,6 +203,6 @@ beta = dd653f0879b48c3ef69e13551239bec4cbcc1c18fe8894de2e9e1c790e182736
 [RFC 6234]: https://www.rfc-editor.org/info/rfc6234
 [RFC 8032]: https://www.rfc-editor.org/info/rfc8032
 [are hard to prove formally]: https://eprint.iacr.org/2020/823
-[require a more convoluted argument for hash domain separation]: https://www.ietf.org/archive/id/draft-irtf-cfrg-vrf-11.html#name-hash-function-domain-separa
+[require a more convoluted argument for hash domain separation]: https://www.ietf.org/archive/id/draft-irtf-cfrg-vrf-15.html#name-hash-function-domain-separa
 [PWHVNRG17]: https://eprint.iacr.org/2017/099
 [irtf-cfrg-hash-to-curve]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-hash-to-curve/


### PR DESCRIPTION
The only [differences on top of draft-irtf-cfrg-vrf-11](https://www.ietf.org/rfcdiff?url1=draft-irtf-cfrg-vrf-11&url2=draft-irtf-cfrg-vrf-15&difftype=--html) were a change to use "secret key" instead of "private key", changes to "Section 3: VRF Security Properties" and "Section 7: Security Considerations" that are purely editorial, and test vectors for the RSA ciphersuites.