### PR TITLE
age-plugin: allow multiple stanzas

### DIFF
--- a/age-plugin.md
+++ b/age-plugin.md
@@ -297,8 +297,7 @@ the plugin then decides whether this response is fatal.
 If any errors occur, the plugin MUST NOT send any stanzas to the client.
 
 Once all file keys have been successfully wrapped to all recipients and identities,
-the plugin sends the resulting stanzas to the client. The plugin MUST NOT return
-more stanzas per file than the number of recipients and identities.
+the plugin sends the resulting stanzas to the client.
 
 Example phase diagram:
 ```


### PR DESCRIPTION
A plugin might be invoked with a single recipient encoding, but return multiple stanzas, e.g. to support multiple formats, to build group aliases, or to act as a proxy.

We tried and failed to figure out why this was added, but it was probably before we properly abstracted file headers stanzas from recipients.