### PR TITLE
Update XAES-256-GCM.md with AES-GEM link

### DIFF
--- a/XAES-256-GCM.md
+++ b/XAES-256-GCM.md
@@ -255,4 +255,4 @@ for key derivation.
 [Double-Nonce-Derive-Key-GCM]: https://iacr.org/submit/files/slides/2024/rwc/rwc2024/105/slides.pdf
 [AES-XGCM]: https://soatok.blog/2022/12/21/extending-the-aes-gcm-nonce-without-nightmare-fuel/
 [OCH / GCH / CIV AEAD family]: https://www.youtube.com/watch?v=7GBzKytVjH4
-[AES-GEM]: 
+[AES-GEM]: https://github.com/trailofbits/aes-gem


### PR DESCRIPTION
The markdown link for AES-GEM was missing a link, so it currently renders the literal text `[AES-GEM]:` at the foot of the document.

I took a guess as to what the link should be, but the GitHub repository seemed like a reasonable first guess. Happy to update it if y'all think it should go elsewhere.