### PR TITLE
Replace application/data with application/octet-stream

### DIFF
--- a/static-ct-api.md
+++ b/static-ct-api.md
@@ -196,7 +196,7 @@ Tiles are served as at
 
     <monitoring prefix>/tile/<L>/<N>[.p/<W>]
 
-with `Content-Type: application/data`.
+with `Content-Type: application/octet-stream`.
 
 `<L>` is the “level” of the tile, and MUST be a decimal ASCII integer between 0
 and 63, with no additional leading zeroes.
@@ -254,7 +254,7 @@ The log entries are served as a “data tile” at
 
     <monitoring prefix>/tile/data/<N>[.p/<W>]
 
-with `Content-Type: application/data`.
+with `Content-Type: application/octet-stream`.
 
 Data tiles SHOULD be compressed at the HTTP layer. Logs MAY use
 `Content-Encoding: gzip` with no negotiation, or any compression algorithm

--- a/tlog-tiles.md
+++ b/tlog-tiles.md
@@ -62,7 +62,7 @@ Tiles are served at
 
 	<prefix>/tile/<L>/<N>[.p/<W>]
 
-with `Content-Type: application/data`.
+with `Content-Type: application/octet-stream`.
 
 `<L>` is the “level” of the tile, and MUST be a decimal ASCII integer between 0
 and 63, with no additional leading zeroes.
@@ -121,7 +121,7 @@ The log entries are served as a “entry bundles” at
 
 	<prefix>/tile/entries/<N>[.p/<W>]
 
-with `Content-Type: application/data`.
+with `Content-Type: application/octet-stream`.
 
 `<N>` and `.p/<W>` have the same meaning as in Merkle Tree tile paths above.
 


### PR DESCRIPTION
This PR changes references to `Content-Type: application/data` to `Content-Type: application/octet-stream` in the `static-ct-api` and `tlog-tiles` specs.

`application/octet-stream` is an [IANA registered type](https://www.iana.org/assignments/media-types/application/octet-stream), but `application/data` is not.