### PR TITLE
static-ct-api: clarify how pre_certificate maps to RFC6962

### DIFF
--- a/static-ct-api.md
+++ b/static-ct-api.md
@@ -284,7 +284,7 @@ opaque Fingerprint[32];
 
 “pre_certificate” is the Precertificate submitted for auditing, corresponding
 to the `pre_certificate` specified in RFC 6962, Section 3.1. It is not the same
-as the PreCert in `timestamped_entry`, which is a TBS certificate.
+as `timestamped_entry.signed_entry`, which is a PreCert containing a TBSCertificate.
 
 “certificate_chain” are the SHA-256 hashes of the ASN.1 encoding of the issuers
 in the submitted chain, corresponding to the `certificate_chain` or

--- a/static-ct-api.md
+++ b/static-ct-api.md
@@ -282,7 +282,9 @@ opaque Fingerprint[32];
 “timestamped_entry” is the `TimestampedEntry` sub-structure of a
 `MerkleTreeLeaf` according to RFC 6962, Section 3.4.
 
-“pre_certificate” is the Precertificate submitted for auditing.
+“pre_certificate” is the Precertificate submitted for auditing, corresponding
+to the `pre_certificate` specified in RFC 6962, Section 3.1. It is not the same
+as the PreCert in `timestamped_entry`, which is a TBS certificate.
 
 “certificate_chain” are the SHA-256 hashes of the ASN.1 encoding of the issuers
 in the submitted chain, corresponding to the `certificate_chain` or


### PR DESCRIPTION
Following up on: https://github.com/C2SP/C2SP/issues/95