### PR TITLE
signed-note: turn invalid sig from known key from MAY to SHOULD reject

### DIFF
--- a/signed-note.md
+++ b/signed-note.md
@@ -71,7 +71,7 @@ The tuple of key name and key ID uniquely identifies the key that performed the
 signature and the algorithm it used. Verifiers MUST ignore signatures from
 unknown keys, even if they share a name or ID (but not both) with a known key.
 If the key name and ID match a known key, verifiers MUST verify the signature.
-If a signature from a known key fails to verify, clients MAY reject the whole
+If a signature from a known key fails to verify, clients SHOULD reject the whole
 note. If no signature from a known key verifies successfully, clients MUST
 reject the note.
 


### PR DESCRIPTION
Generally, it's good to surface issues when they can be detected sooner rather than later, and explicitly if possible.

For example, consider the case of rotating a key. You'll want to use the old and new keys in parallel for a while. If the new key is producing invalid signatures you might not learn about it until you decommission the old key, if clients were failing to verify the signature from the new key but silently ignoring it once they verify the signature from the old key. Instead, stricter clients will fail sooner, ideally in testing.

We live in a post-Postel's world.

Going from MAY to SHOULD is just a recommendation change, it doesn't change the interoperability requirements.

This was discussed at the last Sigsum meetup.