### PR TITLE
Cap max tile level at 6

### DIFF
--- a/static-ct-api.md
+++ b/static-ct-api.md
@@ -199,7 +199,7 @@ Tiles are served as at
 with `Content-Type: application/octet-stream`.
 
 `<L>` is the “level” of the tile, and MUST be a decimal ASCII integer between 0
-and 6, with no additional leading zeroes.
+and 5, with no additional leading zeroes.
 
 `<N>` is the index of the tile within the level. It MUST be a non-negative
 integer encoded into 3-digit path elements. All but the last path element MUST

--- a/static-ct-api.md
+++ b/static-ct-api.md
@@ -199,7 +199,7 @@ Tiles are served as at
 with `Content-Type: application/octet-stream`.
 
 `<L>` is the “level” of the tile, and MUST be a decimal ASCII integer between 0
-and 63, with no additional leading zeroes.
+and 6, with no additional leading zeroes.
 
 `<N>` is the index of the tile within the level. It MUST be a non-negative
 integer encoded into 3-digit path elements. All but the last path element MUST


### PR DESCRIPTION
RFC6962 specifies that a `TreeHeadSignature` includes an `uint64` `tree_size`.  That means that there cannot be more than `2^64` leaves, i.e `2^56` entries bundles, i.e a maximum of 7 tile levels.