### PR TITLE
static-ct-api: Correct the case of the CtExtensions type

### DIFF
--- a/static-ct-api.md
+++ b/static-ct-api.md
@@ -99,9 +99,9 @@ verified.
 		opaque extension_data<0..2^16-1>;
 	} Extension;
 	
-	Extension CTExtensions<0..2^16-1>;
+	Extension CtExtensions<0..2^16-1>;
 
-The `CTExtensions` type (opaque in RFC 6962) MUST be a list of zero or more
+The `CtExtensions` type (opaque in RFC 6962) MUST be a list of zero or more
 `Extension`s, similarly to [RFC 5246][], but with a one-byte `ExtensionType`.
 The order of extensions in an extensions field is arbitrary and MUST be ignored.
 Duplicate extensions with the same `ExtensionType` MUST NOT be included in the


### PR DESCRIPTION
It's "Ct" rather than "CT" in RFC 6962.