### PR TITLE
tlog-tiles: add a title

### DIFF
--- a/tlog-tiles.md
+++ b/tlog-tiles.md
@@ -1,3 +1,4 @@
+# Tiled Transparency Logs
 
 This document specifies an efficient HTTP API to fetch the signed checkpoint,
 Merkle Tree hashes, and entries of a transparency log containing arbitrary


### PR DESCRIPTION
This seems to be the only C2SP document without one. Add one so it's easier to cite. I went with "Tiled Transparency Logs" because that's how the document seems to refer to this ("A tiled transparency log is defined by ...").

The other tlog documents are named like "Transparency Log Cosignatures", which would suggest "Transparency Log Tiles", but the document is the entrypoint for the whole tlog API, so "Tiled Transparency Logs" seemed more appropriate.