### PR TITLE
tlog-witness: change title to match other tlog specs

### DIFF
--- a/tlog-witness.md
+++ b/tlog-witness.md
@@ -1,4 +1,4 @@
-# The Witness Protocol
+# Transparency Log Witnesses
 
 This document describes a synchronous HTTP-based protocol to obtain
 [cosignatures][] from transparency log witnesses.

--- a/tlog-witness.md
+++ b/tlog-witness.md
@@ -1,4 +1,4 @@
-# Transparency Log Witnesses
+# Transparency Log Witness Protocol
 
 This document describes a synchronous HTTP-based protocol to obtain
 [cosignatures][] from transparency log witnesses.


### PR DESCRIPTION
All of the other tlog specs have titles like "Transparency Log Foos", while tlog-witness is "The Witness Protocol". Rename to match.

(I have no horse in this race at all. I just noticed the discrepancy while I was looking at other stuff and figured I'd upload as a mini suggestion. If you all prefer "The Witness Protocol" or it would be annoying to re-title for some reason, just leave it as-is.)