### PR TITLE
tlog-cosignature: be a bit more correct w.r.t. leap seconds

### DIFF
--- a/tlog-cosignature.md
+++ b/tlog-cosignature.md
@@ -64,7 +64,7 @@ The signature MUST be a 72-byte `timestamped_signature` structure.
     }
 
 "timestamp" is the time at which the cosignature was generated, as seconds since
-the UNIX epoch (January 1, 1970 00:00 UTC).
+the UNIX epoch (January 1, 1970 00:00 UTC), excluding leap seconds.
 
 "signature" is an Ed25519 ([RFC 8032][]) signature from the witness public key
 over the message defined in the next section.
@@ -79,8 +79,9 @@ The header line MUST be the fixed string `cosignature/v1`, and provides domain
 separation.
 
 The timestamp line MUST consist of the string `time`, a single space (0x20), and
-the number of seconds since the UNIX epoch encoded as an ASCII decimal with no
-leading zeroes. This value MUST match the `timestamped_signature.timestamp`.
+the number of seconds since the UNIX epoch, excluding leap seconds, encoded as
+an ASCII decimal with no leading zeroes. This value MUST match the
+`timestamped_signature.timestamp`.
 
     cosignature/v1
     time 1679315147


### PR DESCRIPTION
Leap seconds are the worst. I believe, formally, one needs to explicitly exclude them for a description of a POSIX timestamp to be correct. An example in HTTP:
https://www.rfc-editor.org/rfc/rfc9651#name-dates

(Or you do what POSIX does and actually define it as a mathematical expression of the time's UTC name, and just leave unspecified how you relate that back to an actual time.)
https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap04.html#tag_04_19