### PR TITLE
tlog-cosignature: cite stable tlog-mirror URL

### DIFF
--- a/tlog-cosignature.md
+++ b/tlog-cosignature.md
@@ -115,4 +115,4 @@ Merkle tree root in the extension lines".  See [tlog-mirror][] for an example.
 [note signature]: https://c2sp.org/signed-note
 [checkpoint]: https://c2sp.org/tlog-checkpoint
 [witness]: https://c2sp.org/tlog-witness
-[tlog-mirror]: https://github.com/C2SP/C2SP/pull/140/
+[tlog-mirror]: https://c2sp.org/tlog-mirror


### PR DESCRIPTION
The URL has contents now, so no more need to cite a PR.