### PR TITLE
tlog-cosignature: Specify endianness of signature timestamp

### DIFF
--- a/tlog-cosignature.md
+++ b/tlog-cosignature.md
@@ -63,12 +63,12 @@ different key ID algorithm byte (and a different signed message header line).
 The signature MUST be a 72-byte `timestamped_signature` structure.
 
     struct timestamped_signature {
-        u64 timestamp;
+        u8 timestamp[8];
         u8 signature[64];
     }
 
 "timestamp" is the time at which the cosignature was generated, as seconds since
-the UNIX epoch (January 1, 1970 00:00 UTC).
+the UNIX epoch (January 1, 1970 00:00 UTC), encoded in big-endian.
 
 "signature" is an Ed25519 ([RFC 8032][]) signature from the cosigner public key
 over the message defined in the next section.


### PR DESCRIPTION
The `timestamped_signature` struct should be unambiguous in its serialization, but it's not as far as I can tell. I'm assuming it means big-endian bc that's what [torchwood uses](https://pkg.go.dev/golang.org/x/crypto/cryptobyte#String.ReadUint64). Correct me if I'm mistaken on either point!