### PR TITLE
tlog-cosignature: clarify signature serialization

### DIFF
--- a/tlog-cosignature.md
+++ b/tlog-cosignature.md
@@ -71,7 +71,7 @@ The signature MUST be a 72-byte `timestamped_signature` structure.
     }
 
 "timestamp" is the time at which the cosignature was generated, as seconds since
-the UNIX epoch (January 1, 1970 00:00 UTC).
+the UNIX epoch (January 1, 1970 00:00 UTC), serialized as a big-endian integer.
 
 "signature" is an Ed25519 ([RFC 8032][]) signature from the cosigner public key
 over the message defined in the next section.


### PR DESCRIPTION
The spec currently does not mention how to encode the timestamp into a sequence of bytes. While one can guess based on what other specs in its orbit are doing, let's be explicit about what implementations actually expect[1].

[1] https://github.com/transparency-dev/formats/blob/0e991b4666d90e0530b81ddb5e3a7f0307e6b825/note/note_cosigv1.go#L167