### PR TITLE
tlog-cosignature: Limit cosignature timestamps to 63 bits

### DIFF
--- a/tlog-cosignature.md
+++ b/tlog-cosignature.md
@@ -76,7 +76,8 @@ The signature MUST be a 72-byte `timestamped_signature` structure.
     }
 
 "timestamp" is the time at which the cosignature was generated, as a POSIX
-timestamp.
+timestamp.  It MUST NOT exceed 2^63 - 1, and verifiers MAY reject cosignatures
+with timestamps in the future.
 
 "signature" is an Ed25519 ([RFC 8032][]) signature from the cosigner public key
 over the message defined in the next section.


### PR DESCRIPTION
No well behaving witness should use timestamps far into the future. Explicitly limiting the valid range to 0 <= timestamp <= 2^63 - 1 allows implementations to use either a signed or unsigned 64-bit type to represent timestamps, and improves compatibility with Sigsum cosignatures which are similarly restricted to 63 bits.