### PR TITLE
tlog-mirror: Remove the optional list of other mirrors

### DIFF
--- a/tlog-mirror.md
+++ b/tlog-mirror.md
@@ -54,7 +54,6 @@ For each supported origin log, the mirror is configured with:
 * The log's public key
 * The log's URL prefix
 * A minimum index to start mirroring (see below for how this is configured)
-* An optional list of monitoring prefixes for other mirrors for the log
 
 The mirror maintains a copy of each origin log and serves it publicly via the
 [tiled transparency log][] interface. It uses a URL prefix of


### PR DESCRIPTION
This isn't actually used in the spec anywhere, from what I can tell. I think this was a remnant of when this was a pull-based protocol, instead of a push-based protocol.