### PR TITLE
tlog-witness: clarify handling of invalid trusted-key signatures

### DIFF
--- a/tlog-witness.md
+++ b/tlog-witness.md
@@ -108,9 +108,11 @@ Example request body:
 The witness MUST verify the checkpoint signature against the public key(s) it
 trusts for the checkpoint origin, and it MUST ignore signatures from unknown
 keys. If the checkpoint origin is unknown, the witness MUST respond with a "404
-Not Found" HTTP status code. If none of the signatures verify against any of the
-trusted public keys, the witness MUST respond with a "403 Forbidden" HTTP status
-code.
+Not Found" HTTP status code. The witness MUST respond with a "403 Forbidden"
+HTTP status code if either no signature from a trusted key for the origin is
+present, or a signature line's key name and ID match a trusted key but the
+signature itself fails to verify (such a note is malformed per
+[signed-note][]).
 
 The old size MUST be equal to or lower than the checkpoint size. Otherwise,
 the witness MUST respond with a "400 Bad Request" HTTP status code.


### PR DESCRIPTION
The add-checkpoint section currently covers two signature outcomes: at least one trusted-key signature verifies (cosign), or no trusted-key signature verifies (403 Forbidden). But there's a third case: a signature line whose key name and ID match a trusted key for the origin but whose signature bytes fail to verify. Per c2sp.org/signed-note, such a note is malformed and SHOULD be rejected as a whole, but the witness status code wasn't specified.

Clarify that the witness MUST fold this case into the same 403 Forbidden response. Both independent reference implementations already do this:

  - sunlight [1] collapses golang.org/x/mod/sumdb/note.UnverifiedNoteError (no trusted-key sig present) and note.InvalidSignatureError (trusted key, bad sig) onto a single errInvalidSignature → 403 path.

  - sigsum-go [2] returns 403 both when a sig line's KeyId doesn't match the expected log key ("unexpected checkpoint key id") and when the KeyId matches but the signature bytes don't verify ("invalid checkpoint signature").

This aligns the spec with deployed behavior.

[1] https://github.com/FiloSottile/sunlight/blob/8a154da/internal/witness/witness.go#L303-L363
[2] https://git.glasklar.is/sigsum/core/sigsum-go/-/blob/main/cmd/sigsum-witness/sigsum-witness.go
    and pkg/checkpoint/checkpoint.go Checkpoint.Verify