### PR TITLE
mtc-tlog: update pruning text so RPs control when pruning happens

### DIFF
--- a/mtc-tlog.md
+++ b/mtc-tlog.md
@@ -69,9 +69,8 @@ a [transparency log cosigner][] as described below. Issuance logs MAY serve
 additional cosignatures, including ones from cosigners that are not
 [MTC cosigners][MTC cosigner].
 
-If [pruned][], an issuance log MUST set its minimum index such that only expired
-entries are pruned. Relying parties MAY set further restrictions, such as
-requiring that an entry be expired for at least 6 months before pruning.
+If [pruned][], an issuance log MUST NOT set its minimum index larger than the
+smallest minimum index trusted by relying parties.
 
 An issuance log with a landmark sequence MUST [publish active landmarks][] at
 the following URL:

--- a/mtc-tlog.md
+++ b/mtc-tlog.md
@@ -88,9 +88,9 @@ a [transparency log cosigner][] as described below. Issuance logs MAY serve
 additional cosignatures, including ones from cosigners that are not
 [MTC cosigners][MTC cosigner].
 
-If [pruned][], an issuance log MUST set its minimum index such that only expired
-entries are pruned. Relying parties MAY set further restrictions, such as
-requiring that an entry be expired for at least 6 months before pruning.
+Relying parties SHOULD set restrictions on [pruning][], such as requiring
+that the log's minimum index be at most the minimum trusted index in
+up-to-date copies of the relying party's trust anchors
 
 An issuance log with a landmark sequence MUST [publish active landmarks][] at
 the following URL:
@@ -104,7 +104,7 @@ the following URL:
 [MTC cosigner]: https://www.ietf.org/archive/id/draft-ietf-plants-merkle-tree-certs-04.html#name-cosigners
 [note signature]: http://c2sp.org/signed-note
 [prefix URL]: https://c2sp.org/tlog-tiles#parameters
-[pruned]: https://c2sp.org/tlog-tiles#pruning
+[pruning]: https://c2sp.org/tlog-tiles#pruning
 [publish active landmarks]: https://www.ietf.org/archive/id/draft-ietf-plants-merkle-tree-certs-04.html#name-publishing-landmarks
 [transparency log cosigner]: https://c2sp.org/tlog-cosignature
 


### PR DESCRIPTION
For context, my concerns about the current text are based on the following experiences from the WebPKI:

1. On many occasions, CAs have misissued certificates with lifetimes that were longer than permitted. This has never led to a CA being distrusted.

2. Several CT logs have incorporated certificates which expired after the log's intended expiry range.

3. Multiple RPs/UAs regularly take weeks to months to update their CT log lists.

### Concern 1: CAs cannot prune unexpired certificates with erroneously long lifetimes

This could lead to a single unexpired certificate followed by a great many expired certificates, causing the log to grow much larger than expected, increasing costs to multiple parties in the ecosystem.

### Concern 2: Slow log list updates cause alert fatigue for monitors

Consider the following sequence of events:

1. CA prunes their log in accordance with RP policy.
2. Weeks to months pass.
3. RP updates the minimum index in their log list to reflect the log's new minimum index.

During those weeks/months, monitors are unable to retrieve entries from the log despite those entries being trusted by the RP. A decent monitor would complain to its operator, leading to alert fatigue.

### The fix

We _really_ want the order of operations to be:

1. RP updates the minimum index in their log list per their desired policy.
2. CA notices that the minimum index for their log has increased, and prunes their log if desired.

This is analogous to Chrome's existing requirement that CT logs remain operational until they are removed from the log list, even if the log is past its expiry range and contains only expired certificates.

Both concerns are addressed:

1. If an RP decides they don't care about breaking an unexpired certificate with an overly-long lifetime, they can bump the minimum index beyond the certificate, allowing the log to be pruned. This is analogous to Chrome's existing practice of removing CT logs after their expiry range ends, even if the log still contains unexpired certificates.

2. If an RP is slow to update its log list, CAs are not allowed to prune entries, so monitors won't experience errors trying to download them.
