### PR TITLE
tlog-tiles: Upgrade and soften the Ed25519 MTI

### DIFF
--- a/tlog-tiles.md
+++ b/tlog-tiles.md
@@ -47,9 +47,20 @@ with `Content-Type: text/plain; charset=utf-8`.
 This endpoint is mutable, so its headers SHOULD prevent caching beyond a few
 seconds.
 
-If the log is public, or is interacting in any way with the public witness
-network, the checkpoint MUST carry at least one Ed25519 signature by the log.
-The checkpoint MAY carry additional signatures of other types, by the log or
+If the log ecosystem does not provide its own requirements, the following
+signature algorithm recommendations apply:
+
+* If ML-DSA-44 support is available, checkpoints SHOULD carry at least one
+  ML-DSA-44 signature by the log.
+
+* Otherwise, or if compatibility with older log clients is needed, checkpoints
+  SHOULD carry at least one Ed25519 signature by the log.
+
+Checkpoints MAY carry both ML-DSA-44 and Ed25519 signatures by the log. This
+provides quantum resistance for newer log clients, while retaining compatibility
+with older log clients.
+
+Checkpoints MAY carry additional signatures of other types, by the log or
 otherwise.
 
 ### Merkle Tree


### PR DESCRIPTION
MTI algorithms have a habit of not aging terribly well. Soften all recommendations to SHOULD. Also we're in this awkward period where we prefer ML-DSA-44 but it's very new. Try to convey that ML-DSA-44 is preferred, but maybe you don't have it, or maybe your clients don't have it, in which case the older recommendation was Ed25519.

Fixes #275