### PR TITLE
tlog-witness,tlog-mirror: switch percent-encoded origin to origin hash

### DIFF
--- a/tlog-mirror.md
+++ b/tlog-mirror.md
@@ -11,7 +11,6 @@ signatures asserting that a mirror has done so.
 [pruning]: https://c2sp.org/tlog-tiles#pruning
 [retention policy]: https://c2sp.org/tlog-tiles#retention-policies
 [witness]: https://c2sp.org/tlog-witness
-[percent-encoded]: https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1
 [subtree]: https://www.ietf.org/archive/id/draft-ietf-plants-merkle-tree-certs-02.html#name-subtrees
 [subtree consistency proof]: https://www.ietf.org/archive/id/draft-ietf-plants-merkle-tree-certs-02.html#name-subtree-consistency-proofs
 
@@ -57,9 +56,9 @@ For each supported origin log, the mirror is configured with:
 
 The mirror maintains a copy of each origin log and serves it publicly via the
 [tiled transparency log][] interface. It uses a URL prefix of
-`<monitoring prefix>/<encoded origin>`, where `encoded origin` is the log's
-origin, [percent-encoded][]. The checkpoint served from this prefix MUST include
-a [cosignature][] from the mirror.
+`<monitoring prefix>/<origin hash>`, where `origin hash` is the SHA-256 hash of
+the log's origin, hex encoded, in lowercase. The checkpoint served from this
+prefix MUST include a [cosignature][] from the mirror.
 
 ## Updating a Mirror
 

--- a/tlog-witness.md
+++ b/tlog-witness.md
@@ -278,10 +278,10 @@ to coordinate directly with witnesses.
 
 A witness SHOULD serve a recent checkpoint for each log it cosigned.
 
-    GET <monitoring prefix>/<encoded origin>/checkpoint
+    GET <monitoring prefix>/<origin hash>/checkpoint
 
-The request MUST be an HTTP GET. The encoded origin is the log's origin,
-[percent-encoded][]. The response body MUST be a [checkpoint][] for the log
+The request MUST be an HTTP GET. The origin hash is the SHA-256 hash of the log's origin,
+hex encoded, in lowercase. The response body MUST be a [checkpoint][] for the log
 identified by the origin, and it MUST include the cosignature(s) from the
 witness's key(s) that were returned from add-checkpoint and the cosignature from
 the log key(s) that the witness verified.
@@ -292,5 +292,4 @@ with a "404 Not Found" HTTP status code instead.
 The witness MAY delay updating the checkpoint, but SHOULD NOT delay for more
 than an hour. This allows delegating the monitoring prefix to e.g. a CDN.
 
-[percent-encoded]: https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1
 [byzantine-witnesses]: https://git.glasklar.is/sigsum/project/documentation/-/blob/main/archive/2023-11-byzantine-witnesses.pdf


### PR DESCRIPTION
Turns out we picked a bad color for the bike shed.

You _would_ think that the whole point of URL percent-encoding would be to escape special characters, but the HTTP ecosystem seems to have made a mess of it, and in many cases `/foo%2Fbar/checkpoint` will be served as `/foo/bar/checkpoint`, which defeats the point of the escaping.

* Go's net/http.FileServerFS serves based on `r.URL.Path` which is unescaped.
* CloudFront's `%2F` handling is stage- and config-dependent.
* Cloudflare unescapes `%2F` if "*[Normalize URLs to origin](https://developers.cloudflare.com/rules/normalization/)*" is enabled.

This PR switches to a hex-encoded SHA-256 hash. There was no directory listing anyway, so clients had to know the origin they were interested in already. (If we want to change this, which we might, we can add an endpoint to serve origins.) It's definitely safe and edge-case free.

Alternatives include Base64url (straight or of a hash), which is case sensitive and not the Base64 we use in checkpoints, and Base32 (straight or of a hash), which is not used anywhere else and a bit less common. I could be convinced that Base32 is better if anyone has strong opinions, but hex felt like a nicely boring answer.

/cc @C2SP/tlog-witness @C2SP/tlog-mirror