### PR TITLE
tlog-mirror: document sign-subtree

### DIFF
--- a/tlog-mirror.md
+++ b/tlog-mirror.md
@@ -121,6 +121,24 @@ name. The mirror's signature is computed later, as described below.
 If providing both mirror and witness services, the submission prefixes for the
 two services MAY be the same, but the monitoring prefixes MUST be distinct.
 
+### sign-subtree
+
+The mirror implements a [witness][]'s `sign-subtree` endpoint to produce
+cosignatures by the mirror key(s) when provided a checkpoint signed by the
+mirror and a subtree consistency proof.
+
+It is OPTIONAL for a mirror to support this API.
+
+    POST <submission prefix>/sign-subtree
+
+The request is handled identically to that of a witness.
+
+If providing both mirror and witness services, checkpoints signed only with the
+witness key(s), if any, MUST NOT be exchanged for subtrees signed by the mirror key(s).
+If the submission prefixes for the two services are the same, the mirror MUST
+use the same identity (or identities) when signing the subtree as was (or were)
+used to sign and verify the reference checkpoint.
+
 ### add-entries
 
 The mirror implements an `add-entries` endpoint to upload entries for a


### PR DESCRIPTION
add-checkpoint is called out explicitly, so sign-subtree should be, too.

This also documents one thing that might not be obvious: it's ok to have the same submission prefix for witness and mirror, but then you need to tell sign-subtree requests apart by how they are signed. (Not in love with the language, I welcome improvements.)

Marking this OPTIONAL in the general case, mtc-tlog makes it a SHOULD, and root policy will make it a MUST.

/cc @C2SP/tlog-mirror 