### PR TITLE
mtc-tlog: Document that tlog-tiles currently implies SHA-256

### DIFF
--- a/mtc-tlog.md
+++ b/mtc-tlog.md
@@ -41,6 +41,10 @@ ext-mtcTlogPrefixURL EXTENSION ::= {
 }
 ```
 
+[Tiled transparency logs][tiled transparency logs] are currently only defined
+with SHA-256, so MTC CAs following this profile MUST use SHA-256 as the hash
+algorithm.
+
 [CA parameters]: https://www.ietf.org/archive/id/draft-ietf-plants-merkle-tree-certs-04.html#name-certification-authorities
 [represented as an X.509 certificate]: https://www.ietf.org/archive/id/draft-ietf-plants-merkle-tree-certs-04.html#name-representing-certification-
 


### PR DESCRIPTION
Should there be a need to extend this, I think it'll be straightforward to define, if annoying to thread through the ecosystem, but we can cross that bridge if it ever comes. (Just say the log name implicitly determines the hash.)

/cc @C2SP/mtc-tlog
/cc @C2SP/tlog-tiles