### PR TITLE
tlog-checkpoint: Don't allow duplicates in {key name,key id}

### DIFF
--- a/tlog-checkpoint.md
+++ b/tlog-checkpoint.md
@@ -80,6 +80,10 @@ any note signature algorithm based on the ecosystem they operate in. Note that
 the ML-DSA-44 cosignature format doesn't sign the extension lines, which SHOULD
 be empty.
 
+There MAY be multiple signature lines with the same key name. However,
+there MUST NOT be multiple signature lines with both the same key
+name and the same key id.
+
 According to the note specification, clients MUST ignore unknown signatures.
 This enables, for example, log key rotation, and witness cosigning.
 


### PR DESCRIPTION
Duplicate signature lines, i.e., same key name, same key id, same underlying cryptographic key (barring key id collisions), does not add anything useful.

But worse, for cosignatures, such duplicate lines can carry distinct timestamps. By allowing duplicates, any implementation doing useful things with the cosignature timestamps must be prepared to handle the obscure corner case of multiple timestamps by the same key (and with poor guidance from specs on what is the proper behavior). Rejecting duplicates makes things simpler.

The corresponding change has been discussed in some more detail in the Sigsum context, see
https://git.glasklar.is/sigsum/project/documentation/-/blob/main/proposals/2026-05-29-no-duplicate-cosignature-keys.md and
https://git.glasklar.is/sigsum/project/documentation/-/blob/main/archive/2026-06-02--meeting-minutes.md