### PR TITLE
tlog-checkpoint: make tiny clarifications

### DIFF
--- a/tlog-checkpoint.md
+++ b/tlog-checkpoint.md
@@ -20,8 +20,6 @@ CsUYapGGPo4dkMgIAUqom/Xajj7h2fB2MPA3j2jxq2I=
 — example.com/behind-the-sofa Az3grlgtzPICa5OS8npVmf1Myq/5IZniMp+ZJurmRDeOoRDe4URYN7u5/Zhcyv2q1gGzGku9nTo+zyWE+xeMcTOAYQ8=
 ```
 
-[signed note]: https://c2sp.org/signed-note@v1.0.0
-
 ## Conventions used in this document
 
 The base64 encoding used throughout is the standard Base 64 encoding specified
@@ -46,8 +44,8 @@ document are to be interpreted as described in [BCP 14][] [RFC 2119][] [RFC
 
 ## Note text
 
-The note text is a sequence of at least three non-empty lines, separated by
-newlines (U+000A).
+The note text of a checkpoint is a sequence of at least three non-empty lines,
+separated by newlines (U+000A).
 
  1. The first line is the **origin**, a unique identifier for the log identity
     which issued the checkpoint. The origin MUST be non-empty, and it SHOULD be
@@ -69,6 +67,9 @@ newlines (U+000A).
 
 ## Signatures
 
+Adhering to the [signed note][] specification, an empty line separates the note
+text from its signatures.
+
 A log MUST not sign any checkpoint which is inconsistent with any checkpoint it
 previously signed. Two checkpoints are inconsistent if a consistency proof can't
 be constructed from one to the other.
@@ -80,7 +81,8 @@ any note signature algorithm based on the ecosystem they operate in. Note that
 the ML-DSA-44 cosignature format doesn't sign the extension lines, which SHOULD
 be empty.
 
-According to the note specification, clients MUST ignore unknown signatures.
-This enables, for example, log key rotation, and witness cosigning.
+According to the [signed note][] specification, clients MUST ignore unknown
+signatures. This enables, for example, log key rotation, and witness cosigning.
 
 [cosignatures]: https://c2sp.org/tlog-cosignature
+[signed note]: https://c2sp.org/signed-note@v1.0.0


### PR DESCRIPTION
Make it clear that it is a checkpoint's note text that must not have empty lines.

Clarify that the empty line before signature(s) is in signed-note spec.

Harmonize link/text.